### PR TITLE
Add CONTRIBUTING guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,26 @@
+# Contributing to AirAstro
+
+Thank you for your interest in contributing! This repository is divided into a
+Raspberry Pi server and mobile applications for iOS and Android. Before you
+start building, make sure your development environment is ready.
+
+## Server Prerequisites
+
+- **Node.js 20+** – the server is implemented with a lightweight Node.js
+  framework.
+- **INDI/ASCOM drivers** – install the appropriate drivers on your Raspberry Pi
+  or Linux machine.
+- **Raspberry Pi OS or similar** – the server targets a Raspberry Pi but should
+  run on any Linux distribution once the dependencies are installed.
+
+## Mobile App Prerequisites
+
+- **iOS** – Xcode 14 or later on macOS is recommended. The iOS folder contains
+  the application sources.
+- **Android** – Android Studio (Hedgehog or newer) with the Android SDK.
+
+These prerequisites let you build and run the individual projects. According to
+[`AGENTS.md`](AGENTS.md), there are currently no automated tests, so you do not
+need to run any test commands when contributing.
+
+We welcome pull requests that flesh out the project or improve documentation.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ AirAstro is a monorepo aiming to create an open source alternative to commercial
 
 - **iOS application** – a simple user interface to control astrophotography equipment.
 - **Android application** – identical features and interface as the iOS app.
-- **Raspberry Pi server** – runs INDI/ASCOM drivers and exposes control APIs.
+- **Raspberry Pi server** – Node.js service that runs INDI/ASCOM drivers and
+  exposes control APIs.
 
 The goal is to replicate the ASIAIR feature set while staying easy to use. The applications communicate with the server which is designed to run on a Raspberry Pi.
 
@@ -14,7 +15,7 @@ The goal is to replicate the ASIAIR feature set while staying easy to use. The a
 apps/          - Mobile applications
   ios/         - iOS specific code
   android/     - Android specific code
-server/        - Raspberry Pi server implementation
+server/        - Node.js implementation of the Raspberry Pi server
 ```
 
 ## Using Open Source Drivers
@@ -24,3 +25,8 @@ AirAstro relies on the INDI and ASCOM projects to provide hardware support. This
 ## Status
 
 This repository currently contains folder placeholders only. Contributions are welcome to flesh out the server and mobile applications.
+
+## Contributing
+
+Please see [CONTRIBUTING.md](CONTRIBUTING.md) for development prerequisites and
+guidelines.


### PR DESCRIPTION
## Summary
- add contributing instructions with dev prerequisites
- link to new guide from README
- use Node.js instead of Python for the server

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686f97be6378832b97317f76a09b077a