### PR TITLE
Add SwiftUI skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ AirAstro relies on the INDI and ASCOM projects to provide hardware support. This
 
 ## Status
 
-This repository currently contains folder placeholders only. Contributions are welcome to flesh out the server and mobile applications.
+The repository now includes an initial SwiftUI project for iOS with a simple network manager. The Android folder and server remain placeholders for future development. Contributions are welcome to flesh out the server and mobile applications.
 
 ## Contributing
 

--- a/apps/ios/AirAstro/AirAstroApp.swift
+++ b/apps/ios/AirAstro/AirAstroApp.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct AirAstroApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/apps/ios/AirAstro/AppDelegate.swift
+++ b/apps/ios/AirAstro/AppDelegate.swift
@@ -1,0 +1,8 @@
+import UIKit
+
+@main
+class AppDelegate: UIResponder, UIApplicationDelegate {
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        return true
+    }
+}

--- a/apps/ios/AirAstro/ContentView.swift
+++ b/apps/ios/AirAstro/ContentView.swift
@@ -1,0 +1,18 @@
+import SwiftUI
+
+struct ContentView: View {
+    var body: some View {
+        VStack {
+            Text("AirAstro")
+                .font(.largeTitle)
+            Text("Connecting...")
+        }
+        .padding()
+    }
+}
+
+struct ContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        ContentView()
+    }
+}

--- a/apps/ios/AirAstro/Info.plist
+++ b/apps/ios/AirAstro/Info.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleName</key>
+    <string>AirAstro</string>
+</dict>
+</plist>

--- a/apps/ios/AirAstro/NetworkManager.swift
+++ b/apps/ios/AirAstro/NetworkManager.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+class NetworkManager {
+    static let shared = NetworkManager()
+    private init() {}
+
+    private let session = URLSession(configuration: .default)
+
+    func request(_ path: String, completion: @escaping (Result<Data, Error>) -> Void) {
+        guard let url = URL(string: "http://raspberrypi.local" + path) else {
+            completion(.failure(NSError(domain: "", code: 0, userInfo: [NSLocalizedDescriptionKey: "Invalid URL"])))
+            return
+        }
+
+        session.dataTask(with: url) { data, response, error in
+            if let error = error {
+                completion(.failure(error))
+            } else if let data = data {
+                completion(.success(data))
+            } else {
+                completion(.failure(NSError(domain: "", code: 0, userInfo: [NSLocalizedDescriptionKey: "No data"])))
+            }
+        }.resume()
+    }
+}

--- a/apps/ios/README.md
+++ b/apps/ios/README.md
@@ -1,1 +1,14 @@
 # iOS App
+
+This folder contains the Xcode project for the AirAstro iOS application. The project is a SwiftUI app with a simple network manager used to communicate with the Raspberry Pi server.
+
+## Structure
+
+- `AirAstroApp.swift` – entry point for the SwiftUI application.
+- `ContentView.swift` – basic UI showing connection status.
+- `NetworkManager.swift` – lightweight helper for HTTP requests to the server.
+- `Info.plist` – minimal application configuration.
+
+## Building
+
+Open the `AirAstro` folder in Xcode and run the app in the simulator or on an iOS device.


### PR DESCRIPTION
## Summary
- create a minimal SwiftUI project in `apps/ios`
- implement simple network manager
- document the iOS project
- update repository status in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686f9ec6509c832b91f66a8b911d2bc3