### PR TITLE
Add hotspot startup script

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -1,1 +1,24 @@
 # Server
+
+This directory contains the Raspberry Pi server code for AirAstro.
+
+## Wi-Fi Hotspot
+
+On boot the Raspberry Pi automatically starts a Wi-Fi hotspot so that the mobile apps can connect directly. The hotspot SSID begins with `AirAstro-` followed by the last five characters of the Pi's hardware serial number. The default password is `123456789`.
+
+The behaviour is implemented by `scripts/start-hotspot.js` and a companion systemd service file `scripts/start-hotspot.service`.
+
+### Installation
+
+1. Copy the service file and enable it:
+   ```bash
+   sudo cp server/scripts/start-hotspot.service /etc/systemd/system/
+   sudo systemctl enable start-hotspot.service
+   ```
+2. Reboot the Raspberry Pi or start the service manually:
+   ```bash
+   sudo systemctl start start-hotspot.service
+   ```
+
+The script uses `nmcli` to create the hotspot on `wlan0`.
+

--- a/server/scripts/start-hotspot.js
+++ b/server/scripts/start-hotspot.js
@@ -1,0 +1,35 @@
+const { execSync } = require('child_process');
+const fs = require('fs');
+
+function getSerial() {
+  try {
+    const cpuinfo = fs.readFileSync('/proc/cpuinfo', 'utf8');
+    const line = cpuinfo.split('\n').find(l => l.startsWith('Serial'));
+    if (line) {
+      const serial = line.split(':')[1].trim();
+      return serial;
+    }
+  } catch (err) {
+    console.error('Unable to read CPU serial:', err);
+  }
+  return '00000';
+}
+
+function generateSSID() {
+  const serial = getSerial();
+  const id = serial.slice(-5).toUpperCase();
+  return `AirAstro-${id}`;
+}
+
+function startHotspot() {
+  const ssid = generateSSID();
+  const password = '123456789';
+  try {
+    execSync(`nmcli device wifi hotspot ifname wlan0 ssid ${ssid} password ${password}`, { stdio: 'inherit' });
+  } catch (err) {
+    console.error('Failed to start hotspot:', err);
+    process.exit(1);
+  }
+}
+
+startHotspot();

--- a/server/scripts/start-hotspot.service
+++ b/server/scripts/start-hotspot.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Start AirAstro Wi-Fi Hotspot
+After=network.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/node /home/pi/AirAstro/server/scripts/start-hotspot.js
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target
+


### PR DESCRIPTION
## Summary
- start a Wi-Fi hotspot on boot using nmcli and the Pi serial
- add a systemd service so it runs automatically
- document hotspot setup in the server README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686fb864f694832bb73d10306ce2fcea