### PR TITLE
Add server update endpoints

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -20,6 +20,16 @@ For development you can run `npm run dev` to start the server using `ts-node` wi
 
 The server listens on the port specified by the `PORT` environment variable (defaults to `3000`). A simple health check endpoint is available at `/api/ping`.
 
+### Update API
+
+The Pi can check for new versions of AirAstro using GitHub releases. Three endpoints are exposed:
+
+1. `GET /api/update/check` – returns information about the latest release and whether an update is available.
+2. `POST /api/update/download` – downloads the latest release archive when an update is available.
+3. `POST /api/update/install` – installs the downloaded archive, backing up the current server before replacing it.
+
+If installation fails the backup is restored automatically. After a successful install the service should be restarted to run the new code.
+
 ## Wi-Fi Hotspot
 
 On boot the Raspberry Pi automatically starts a Wi-Fi hotspot so that the mobile apps can connect directly. The hotspot SSID begins with `AirAstro-` followed by the last five characters of the Pi's hardware serial number. The default password is `123456789`.

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,10 +1,49 @@
 import express, { Request, Response } from 'express';
+import path from 'path';
+import { promises as fs } from 'fs';
+import { checkForUpdate, downloadUpdate, installUpdate } from './update';
 
 const app = express();
 const port: number = parseInt(process.env.PORT ?? '3000', 10);
 
 app.get('/api/ping', (_req: Request, res: Response) => {
   res.json({ status: 'ok' });
+});
+
+app.get('/api/update/check', async (_req: Request, res: Response) => {
+  try {
+    const info = await checkForUpdate();
+    res.json(info);
+  } catch (err: any) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+app.post('/api/update/download', async (_req: Request, res: Response) => {
+  try {
+    const archive = await downloadUpdate();
+    if (!archive) {
+      return res.json({ message: 'Already up to date' });
+    }
+    res.json({ archive });
+  } catch (err: any) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+app.post('/api/update/install', async (_req: Request, res: Response) => {
+  try {
+    const files = await fs.readdir('updates');
+    const archives = files.filter(f => f.endsWith('.tar.gz')).sort();
+    const latest = archives.pop();
+    if (!latest) {
+      return res.status(400).json({ error: 'No downloaded update found' });
+    }
+    await installUpdate(path.join('updates', latest));
+    res.json({ installed: latest });
+  } catch (err: any) {
+    res.status(500).json({ error: err.message });
+  }
 });
 
 app.listen(port, () => {

--- a/server/src/update.ts
+++ b/server/src/update.ts
@@ -1,0 +1,79 @@
+import { exec as execCallback } from 'child_process';
+import { promisify } from 'util';
+import { promises as fs } from 'fs';
+import path from 'path';
+
+const exec = promisify(execCallback);
+
+const REPO_OWNER = 'airastro';
+const REPO_NAME = 'airastro';
+
+function compareVersions(a: string, b: string): number {
+  const pa = a.split('.').map(Number);
+  const pb = b.split('.').map(Number);
+  for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
+    const diff = (pa[i] || 0) - (pb[i] || 0);
+    if (diff) return diff;
+  }
+  return 0;
+}
+
+async function getPackageVersion(): Promise<string> {
+  const pkgPath = path.join(__dirname, '..', 'package.json');
+  const data = await fs.readFile(pkgPath, 'utf8');
+  const pkg = JSON.parse(data);
+  return pkg.version as string;
+}
+
+export async function checkForUpdate() {
+  const current = await getPackageVersion();
+  const res = await fetch(`https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/releases/latest`, {
+    headers: { 'User-Agent': 'AirAstro-Server' }
+  });
+  if (!res.ok) {
+    throw new Error(`GitHub API responded with ${res.status}`);
+  }
+  const release = await res.json() as any;
+  const latest = (release.tag_name as string).replace(/^v/, '');
+  const updateAvailable = compareVersions(current, latest) < 0;
+  return { updateAvailable, latestVersion: latest, currentVersion: current, tarballUrl: release.tarball_url as string };
+}
+
+export async function downloadUpdate(): Promise<string> {
+  const info = await checkForUpdate();
+  if (!info.updateAvailable) return '';
+  await fs.mkdir('updates', { recursive: true });
+  const archivePath = path.join('updates', `release-${info.latestVersion}.tar.gz`);
+  const res = await fetch(info.tarballUrl, { headers: { 'User-Agent': 'AirAstro-Server' } });
+  if (!res.ok || !res.body) {
+    throw new Error('Failed to download update');
+  }
+  const fileStream = (await fs.open(archivePath, 'w')).createWriteStream();
+  await new Promise((resolve, reject) => {
+    res.body!.pipe(fileStream);
+    res.body!.on('error', reject);
+    fileStream.on('finish', resolve);
+  });
+  return archivePath;
+}
+
+export async function installUpdate(archivePath: string) {
+  const extractDir = path.join('updates', 'extracted');
+  await fs.rm(extractDir, { recursive: true, force: true });
+  await fs.mkdir(extractDir, { recursive: true });
+  await exec(`tar -xzf ${archivePath} -C ${extractDir}`);
+  const dirs = await fs.readdir(extractDir);
+  if (dirs.length === 0) throw new Error('Extraction failed');
+  const newServerPath = path.join(extractDir, dirs[0], 'server');
+  const backupDir = `server_backup_${Date.now()}`;
+  await fs.cp('server', backupDir, { recursive: true });
+  try {
+    await fs.rm('server', { recursive: true, force: true });
+    await fs.cp(newServerPath, 'server', { recursive: true });
+    await exec('cd server && npm install && npm run build');
+  } catch (err) {
+    await fs.rm('server', { recursive: true, force: true }).catch(() => {});
+    await fs.cp(backupDir, 'server', { recursive: true });
+    throw err;
+  }
+}


### PR DESCRIPTION
## Summary
- add endpoints to check/download/install updates from GitHub releases
- implement update helper with backup recovery
- document the update API in server README

## Testing
- `npm run build` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_686fbbfe41ac832b8dafacae5834c277