### PR TITLE
Add Raspberry Pi setup script

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -49,3 +49,14 @@ The behaviour is implemented by `scripts/start-hotspot.js` and a companion syste
    ```
 
 The script uses `nmcli` to create the hotspot on `wlan0`.
+
+## Quick Install on Raspberry Pi
+
+Run the following command on your Raspberry Pi to install AirAstro and configure all services:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/thibautrey/AirAstro/main/server/scripts/install-on-rpi.sh | bash
+```
+
+The script installs dependencies, clones this repository to `~/AirAstro`, builds the server and sets up systemd services for the server and Wi-Fi hotspot.
+

--- a/server/scripts/install-on-rpi.sh
+++ b/server/scripts/install-on-rpi.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+set -e
+
+INSTALL_DIR=${AIRASTRO_DIR:-$HOME/AirAstro}
+REPO_URL="https://github.com/thibautrey/AirAstro.git"
+BRANCH="main"
+
+log() { echo -e "\033[1;32m[AirAstro]\033[0m $*"; }
+error() { echo -e "\033[1;31m[Error]\033[0m $*" >&2; }
+
+if [ "$(id -u)" -ne 0 ] && ! command -v sudo >/dev/null; then
+  echo "This script requires root privileges or sudo" >&2
+  exit 1
+fi
+
+run() { if [ "$(id -u)" -eq 0 ]; then bash -c "$*"; else sudo bash -c "$*"; fi }
+
+log "Updating package lists"
+run "apt-get update -y"
+run "apt-get install -y git curl build-essential"
+
+if ! command -v node >/dev/null || [ "$(node -v | cut -d. -f1 | tr -d 'v')" -lt 20 ]; then
+  log "Installing Node.js 20"
+  run "curl -fsSL https://deb.nodesource.com/setup_20.x | bash -"
+  run "apt-get install -y nodejs"
+fi
+
+if [ -d "$INSTALL_DIR/.git" ]; then
+  log "Updating existing AirAstro repository"
+  git -C "$INSTALL_DIR" pull --ff-only || { error "Failed to update repository"; exit 1; }
+else
+  log "Cloning AirAstro repository to $INSTALL_DIR"
+  git clone "$REPO_URL" "$INSTALL_DIR" || { error "Failed to clone repository"; exit 1; }
+fi
+
+cd "$INSTALL_DIR/server"
+
+log "Installing server dependencies"
+npm install --omit=dev
+
+log "Building server"
+npm run build
+
+log "Installing hotspot service"
+run "cp $INSTALL_DIR/server/scripts/start-hotspot.service /etc/systemd/system/"
+run "systemctl enable start-hotspot.service"
+
+AIRASTRO_SERVICE=/etc/systemd/system/airastro.service
+TARGET_USER=${SUDO_USER:-$(whoami)}
+
+log "Configuring AirAstro systemd service"
+tmpfile=$(mktemp)
+cat <<SERVICE > "$tmpfile"
+[Unit]
+Description=AirAstro Server
+After=network.target
+
+[Service]
+WorkingDirectory=$INSTALL_DIR/server
+ExecStart=/usr/bin/node $INSTALL_DIR/server/dist/index.js
+Restart=on-failure
+User=$TARGET_USER
+Environment=NODE_ENV=production
+
+[Install]
+WantedBy=multi-user.target
+SERVICE
+run "mv $tmpfile $AIRASTRO_SERVICE"
+run "systemctl daemon-reload"
+run "systemctl enable airastro.service"
+run "systemctl restart airastro.service"
+
+log "Installation complete!"
+


### PR DESCRIPTION
## Summary
- add `install-on-rpi.sh` script to automate server installation
- document one-line install command in `server/README.md`

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686fbdcccf94832b9a82c853b8e6649e