### PR TITLE
Add driver search and install endpoints

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -2,9 +2,12 @@ import express, { Request, Response } from 'express';
 import path from 'path';
 import { promises as fs } from 'fs';
 import { checkForUpdate, downloadUpdate, installUpdate } from './update';
+import { DriverManager } from './indi';
 
 const app = express();
+app.use(express.json());
 const port: number = parseInt(process.env.PORT ?? '3000', 10);
+const driverManager = new DriverManager();
 
 app.get('/api/ping', (_req: Request, res: Response) => {
   res.json({ status: 'ok' });
@@ -41,6 +44,77 @@ app.post('/api/update/install', async (_req: Request, res: Response) => {
     }
     await installUpdate(path.join('updates', latest));
     res.json({ installed: latest });
+  } catch (err: any) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+app.get('/api/drivers', async (_req: Request, res: Response) => {
+  try {
+    const installed = await driverManager.getInstalledDrivers();
+    const running = driverManager.listRunningDrivers();
+    res.json({ installed, running });
+  } catch (err: any) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+app.get('/api/drivers/available', async (_req: Request, res: Response) => {
+  try {
+    const drivers = await driverManager.getAvailableDrivers();
+    res.json(drivers);
+  } catch (err: any) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+app.get('/api/drivers/search', async (req: Request, res: Response) => {
+  const query = (req.query.q as string) ?? '';
+  if (!query) {
+    return res.json([]);
+  }
+  try {
+    const results = await driverManager.searchDrivers(query);
+    res.json(results);
+  } catch (err: any) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+app.post('/api/drivers/start', async (req: Request, res: Response) => {
+  const { name } = req.body as { name?: string };
+  if (!name) {
+    return res.status(400).json({ error: 'Driver name required' });
+  }
+  try {
+    await driverManager.startDriver(name);
+    res.json({ started: name });
+  } catch (err: any) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+app.post('/api/drivers/stop', async (req: Request, res: Response) => {
+  const { name } = req.body as { name?: string };
+  if (!name) {
+    return res.status(400).json({ error: 'Driver name required' });
+  }
+  try {
+    await driverManager.stopDriver(name);
+    res.json({ stopped: name });
+  } catch (err: any) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+app.post('/api/drivers/install', async (req: Request, res: Response) => {
+  const { name } = req.body as { name?: string };
+  if (!name) {
+    return res.status(400).json({ error: 'Driver name required' });
+  }
+  try {
+    await driverManager.installDriver(name);
+    res.json({ installed: name });
   } catch (err: any) {
     res.status(500).json({ error: err.message });
   }

--- a/server/src/indi.ts
+++ b/server/src/indi.ts
@@ -1,0 +1,121 @@
+import { promises as fs } from 'fs';
+import { spawn, ChildProcess, exec as execCallback } from 'child_process';
+import path from 'path';
+import { promisify } from 'util';
+
+const exec = promisify(execCallback);
+
+export class DriverManager {
+  private searchDirs: string[];
+  private running: Map<string, ChildProcess> = new Map();
+  private availableCache?: { names: string[]; timestamp: number };
+
+  constructor() {
+    this.searchDirs = [
+      '/usr/local/bin',
+      '/usr/bin',
+      '/usr/local/lib/indi',
+      '/usr/lib/indi'
+    ];
+  }
+
+  private async fetchDriverNamesFromGitHub(repo: string): Promise<string[]> {
+    const url = `https://api.github.com/repos/${repo}/git/trees/master?recursive=1`;
+    const res = await fetch(url, { headers: { 'User-Agent': 'AirAstro-Server' } });
+    if (!res.ok) {
+      throw new Error(`GitHub API responded with ${res.status}`);
+    }
+    const data = (await res.json()) as { tree: { path: string; type: string }[] };
+    const names = new Set<string>();
+    for (const item of data.tree) {
+      if (item.type === 'blob' && item.path.startsWith('drivers/') && item.path.endsWith('CMakeLists.txt')) {
+        const parts = item.path.split('/');
+        if (parts.length >= 3) {
+          names.add(parts[parts.length - 2]);
+        }
+      }
+    }
+    return Array.from(names);
+  }
+
+  async getAvailableDrivers(): Promise<string[]> {
+    const cacheDuration = 60 * 60 * 1000; // 1 hour
+    if (this.availableCache && Date.now() - this.availableCache.timestamp < cacheDuration) {
+      return this.availableCache.names;
+    }
+    const repos = ['indilib/indi', 'indilib/indi-3rdparty'];
+    const lists = await Promise.all(repos.map(r => this.fetchDriverNamesFromGitHub(r)));
+    const names = Array.from(new Set(lists.flat())).sort();
+    this.availableCache = { names, timestamp: Date.now() };
+    return names;
+  }
+
+  async searchDrivers(query: string): Promise<string[]> {
+    const lower = query.toLowerCase();
+    const names = await this.getAvailableDrivers();
+    return names.filter(n => n.toLowerCase().includes(lower));
+  }
+
+  async installDriver(packageName: string): Promise<void> {
+    await exec(`sudo apt-get update`);
+    await exec(`sudo apt-get install -y ${packageName}`);
+  }
+
+  async getInstalledDrivers(): Promise<string[]> {
+    const found = new Set<string>();
+    for (const dir of this.searchDirs) {
+      try {
+        const files = await fs.readdir(dir);
+        for (const file of files) {
+          if (file.startsWith('indi_')) {
+            found.add(file);
+          }
+        }
+      } catch {
+        // ignore missing directories
+      }
+    }
+    return Array.from(found).sort();
+  }
+
+  private async findDriverPath(name: string): Promise<string> {
+    if (path.isAbsolute(name)) {
+      return name;
+    }
+    for (const dir of this.searchDirs) {
+      const full = path.join(dir, name);
+      try {
+        await fs.access(full);
+        return full;
+      } catch {
+        // try next
+      }
+    }
+    return '';
+  }
+
+  async startDriver(name: string): Promise<void> {
+    if (this.running.has(name)) return;
+    const driverPath = await this.findDriverPath(name);
+    if (!driverPath) {
+      throw new Error(`Driver ${name} not found`);
+    }
+    const child = spawn(driverPath, [], { stdio: ['ignore', 'pipe', 'pipe'] });
+    child.on('exit', () => {
+      this.running.delete(name);
+    });
+    this.running.set(name, child);
+  }
+
+  async stopDriver(name: string): Promise<void> {
+    const proc = this.running.get(name);
+    if (proc) {
+      proc.kill();
+      this.running.delete(name);
+    }
+  }
+
+  listRunningDrivers(): string[] {
+    return Array.from(this.running.keys());
+  }
+}


### PR DESCRIPTION
## Summary
- enhance `DriverManager` with GitHub driver discovery, caching and search
- add ability to install drivers using apt
- expose `/api/drivers/available`, `/api/drivers/search` and `/api/drivers/install` endpoints

## Testing
- `npm run build` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_686fc344e1c8832bbff089b7c61e72d5