### PR TITLE
Add USB device scan endpoint

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -50,6 +50,15 @@ app.get("/api/drivers/search", async (req: Request, res: Response) => {
   }
 });
 
+app.get("/api/drivers/usb", async (_req: Request, res: Response) => {
+  try {
+    const devices = await driverManager.listUsbDevices();
+    res.json(devices);
+  } catch (err: any) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
 app.post("/api/drivers/start", async (req: Request, res: Response) => {
   const { name } = req.body as { name?: string };
   if (!name) {


### PR DESCRIPTION
## Summary
- extend DriverManager with `listUsbDevices` method
- expose `/api/drivers/usb` endpoint to list detected USB devices and match them with installed drivers

## Testing
- `npm run build` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_686fc97fca8c832b82d9f37a46e311f9