### PR TITLE
Centralize driver management

### DIFF
--- a/EQUIPMENT_IMPLEMENTATION.md
+++ b/EQUIPMENT_IMPLEMENTATION.md
@@ -53,9 +53,9 @@ Support automatique pour :
 
 ### Scripts d'Installation
 
-#### 🛠️ Scripts Bash
+-#### 🛠️ Scripts Bash
 
-- **`install-indi-drivers.sh`** : Installation complète des drivers INDI
+- **`maintain-indi-drivers.sh`** : Installation et mise à jour complètes des drivers INDI
 - **`auto-configure-equipment.sh`** : Configuration automatique au démarrage
 - **`test-equipment-detection.sh`** : Tests complets du système
 
@@ -125,7 +125,8 @@ User Opens Setup Screen → Fetch Equipment → Display Cards → Click Auto Con
 
 ```bash
 # Installation complète sur Raspberry Pi
-sudo ./scripts/install-indi-drivers.sh
+sudo ./scripts/maintain-indi-drivers.sh install-missing
+sudo ./scripts/maintain-indi-drivers.sh update-all
 
 # Test du système
 ./scripts/test-equipment-detection.sh

--- a/server/EQUIPMENT_DETECTION.md
+++ b/server/EQUIPMENT_DETECTION.md
@@ -100,8 +100,9 @@ Exécutez le script d'installation :
 
 ```bash
 cd /path/to/airastro/server
-chmod +x scripts/install-indi-drivers.sh
-./scripts/install-indi-drivers.sh
+chmod +x scripts/maintain-indi-drivers.sh
+./scripts/maintain-indi-drivers.sh install-missing
+./scripts/maintain-indi-drivers.sh update-all
 ```
 
 ### Installation Manuelle

--- a/server/scripts/INSTALL_DRIVERS_README.md
+++ b/server/scripts/INSTALL_DRIVERS_README.md
@@ -6,15 +6,15 @@ Ce répertoire contient plusieurs scripts pour l'installation des drivers INDI n
 
 ### Scripts principaux
 
-1. **`install-all-drivers.sh`** - Script unifié (recommandé)
+1. **`maintain-indi-drivers.sh`** - Script unifié de maintenance
 
-   - Combine l'installation des drivers essentiels et complets
-   - Options : `--essential-only` ou `--full`
-   - Utilisé par défaut dans `install-on-rpi.sh`
+   - Installe tous les drivers manquants
+   - Met à jour les drivers existants
+   - Peut configurer une mise à jour automatique quotidienne
 
 2. **`install-on-rpi.sh`** - Script d'installation principal
    - Installe AirAstro complet sur Raspberry Pi
-   - Inclut l'installation des drivers INDI
+   - Appelle `maintain-indi-drivers.sh` pour installer tous les drivers
    - Configure les services système
 
 ### Scripts de drivers individuels
@@ -35,21 +35,19 @@ Ce répertoire contient plusieurs scripts pour l'installation des drivers INDI n
 ### Installation complète (recommandé)
 
 ```bash
-# Via le script unifié
-./install-all-drivers.sh --full
-
-# Via le script principal
+# Installation via le script principal
 ./install-on-rpi.sh
+
+# Ou directement avec le script de maintenance
+./maintain-indi-drivers.sh install-missing
+./maintain-indi-drivers.sh update-all
 ```
 
 ### Installation minimale
 
 ```bash
 # Uniquement les drivers essentiels
-./install-all-drivers.sh --essential-only
-
-# Ou directement
-./install-drivers.sh
+./maintain-indi-drivers.sh install-from-db
 ```
 
 ### Installation manuelle avancée
@@ -64,10 +62,8 @@ Ce répertoire contient plusieurs scripts pour l'installation des drivers INDI n
 
 ## Ordre d'exécution recommandé
 
-1. **`install-on-rpi.sh`** appelle automatiquement `install-all-drivers.sh`
-2. **`install-all-drivers.sh`** exécute dans l'ordre :
-   - `install-drivers.sh` (drivers essentiels)
-   - `install-indi-drivers.sh full` (drivers complets)
+1. **`install-on-rpi.sh`** utilise `maintain-indi-drivers.sh`
+2. **`maintain-indi-drivers.sh`** peut installer les drivers manquants puis mettre à jour l'ensemble
 
 ## Logs et diagnostic
 
@@ -88,9 +84,7 @@ Tous les scripts sont compatibles avec :
 Pour mettre à jour les drivers :
 
 ```bash
-# Réinstaller tous les drivers
-./install-all-drivers.sh --full
-
-# Ou utiliser le script de maintenance
-./maintain-indi-drivers.sh
+# Utiliser le script de maintenance
+./maintain-indi-drivers.sh install-missing
+./maintain-indi-drivers.sh update-all
 ```

--- a/server/scripts/README.md
+++ b/server/scripts/README.md
@@ -44,19 +44,14 @@ Le système AirAstro télécharge et installe automatiquement **TOUS** les drive
 
 ## 📋 Scripts Disponibles
 
-### 1. `install-indi-drivers.sh`
+### 1. `maintain-indi-drivers.sh`
 
-**Script principal d'installation des drivers INDI**
+**Script principal de maintenance et d'installation des drivers INDI**
 
 ```bash
 # Installation complète (prioritaires + tous les autres)
-./install-indi-drivers.sh full
-
-# Installation des drivers prioritaires uniquement
-./install-indi-drivers.sh priority
-
-# Mise à jour des drivers existants
-./install-indi-drivers.sh update
+./maintain-indi-drivers.sh install-missing
+./maintain-indi-drivers.sh update-all
 ```
 
 **Fonctionnalités :**
@@ -66,9 +61,9 @@ Le système AirAstro télécharge et installe automatiquement **TOUS** les drive
 - Configuration automatique des permissions USB
 - Création du service INDI systemd
 
-### 2. `maintain-indi-drivers.sh`
+### 2. `update-airastro-system.sh`
 
-**Script de maintenance et mise à jour des drivers**
+**Script de mise à jour complète du système**
 
 ```bash
 # Lister les drivers disponibles
@@ -87,9 +82,9 @@ Le système AirAstro télécharge et installe automatiquement **TOUS** les drive
 ./maintain-indi-drivers.sh setup-auto-update
 ```
 
-### 3. `update-airastro-system.sh`
+### 3. `startup-drivers.sh`
 
-**Script de mise à jour complète du système**
+**Script de démarrage automatique**
 
 ```bash
 # Mise à jour complète
@@ -99,9 +94,9 @@ Le système AirAstro télécharge et installe automatiquement **TOUS** les drive
 ./update-airastro-system.sh --drivers-only
 ```
 
-### 4. `startup-drivers.sh`
+### 4. `install-indi-drivers.sh` *(legacy)*
 
-**Script de démarrage automatique**
+**Ancien script d'installation complet (toujours disponible au besoin)**
 
 Ce script s'exécute automatiquement au démarrage du serveur AirAstro.
 
@@ -127,7 +122,8 @@ Ce script s'exécute automatiquement au démarrage du serveur AirAstro.
 ```bash
 cd /path/to/airastro/server/scripts
 chmod +x *.sh
-./install-indi-drivers.sh full
+./maintain-indi-drivers.sh install-missing
+./maintain-indi-drivers.sh update-all
 ```
 
 ### 2. Configuration de la mise à jour automatique

--- a/server/scripts/install-on-rpi.sh
+++ b/server/scripts/install-on-rpi.sh
@@ -70,22 +70,15 @@ fi
 
 # Installation des drivers INDI
 log "Installation des drivers INDI"
-if [ -f "$INSTALL_DIR/server/scripts/install-all-drivers.sh" ]; then
-  chmod +x "$INSTALL_DIR/server/scripts/install-all-drivers.sh"
-  "$INSTALL_DIR/server/scripts/install-all-drivers.sh" --full
+if [ -f "$INSTALL_DIR/server/scripts/maintain-indi-drivers.sh" ]; then
+  chmod +x "$INSTALL_DIR/server/scripts/maintain-indi-drivers.sh"
+  "$INSTALL_DIR/server/scripts/maintain-indi-drivers.sh" install-missing
+  "$INSTALL_DIR/server/scripts/maintain-indi-drivers.sh" update-all
+  "$INSTALL_DIR/server/scripts/maintain-indi-drivers.sh" setup-auto-update
 else
-  log "Script d'installation unifié des drivers non trouvé, utilisation des scripts individuels"
-
-  # Fallback vers les scripts individuels
-  if [ -f "$INSTALL_DIR/server/scripts/install-drivers.sh" ]; then
-    chmod +x "$INSTALL_DIR/server/scripts/install-drivers.sh"
-    "$INSTALL_DIR/server/scripts/install-drivers.sh"
-  fi
-
-  if [ -f "$INSTALL_DIR/server/scripts/install-indi-drivers.sh" ]; then
-    chmod +x "$INSTALL_DIR/server/scripts/install-indi-drivers.sh"
-    "$INSTALL_DIR/server/scripts/install-indi-drivers.sh" full
-  fi
+  log "Script de maintenance des drivers non trouvé, installation minimale via apt-get"
+  sudo apt-get update
+  sudo apt-get install -y indi-bin indi-full
 fi
 
 AIRASTRO_SERVICE=/etc/systemd/system/airastro.service

--- a/server/scripts/quick-status.sh
+++ b/server/scripts/quick-status.sh
@@ -16,10 +16,10 @@ echo "$(printf '═%.0s' {1..45})"
 echo ""
 
 # Vérifier les processus d'installation
-if pgrep -f "install-indi-drivers.sh\|apt-get install" > /dev/null 2>&1; then
+if pgrep -f "maintain-indi-drivers.sh\|install-indi-drivers.sh\|apt-get install" > /dev/null 2>&1; then
     echo -e "${GREEN}🔄 Installation en cours${NC}"
     echo "   Processus actifs:"
-    pgrep -f "install-indi-drivers.sh\|apt-get install" | while read pid; do
+    pgrep -f "maintain-indi-drivers.sh\|install-indi-drivers.sh\|apt-get install" | while read pid; do
         echo -e "   PID: ${YELLOW}$pid${NC}"
     done
 else


### PR DESCRIPTION
## Summary
- switch `install-on-rpi.sh` to use `maintain-indi-drivers.sh`
- update docs to reference the unified script
- tweak `quick-status.sh` to monitor the new script

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6870c3dcf1dc832b81a5881ef0188667